### PR TITLE
OLED Theme

### DIFF
--- a/common/src/androidMain/AndroidManifest.xml
+++ b/common/src/androidMain/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:name="dev.zwander.common.App"
-        android:theme="@style/AppTheme"
+        android:theme="@style/AppTheme.OLED"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round">
         <!--suppress AndroidDomInspection -->

--- a/common/src/androidMain/res/values/colors.xml
+++ b/common/src/androidMain/res/values/colors.xml
@@ -1,6 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Existing colors -->
     <color name="actual_icon_color_one">@color/icon_color_one</color>
     <color name="actual_icon_color_two">@color/icon_color_two</color>
     <color name="icon_foreground_color">@android:color/white</color>
+
+    <!-- OLED Theme Colors -->
+    <!-- Pure black for OLED displays -->
+    <color name="oled_black">#000000</color>
+    
+    <!-- White and gray variations -->
+    <color name="oled_white">#FFFFFF</color>
+    <color name="oled_gray_light">#CCCCCC</color>
+    <color name="oled_gray">#999999</color>
+    <color name="oled_gray_dark">#666666</color>
+    <color name="oled_gray_darker">#333333</color>
+    
+    <!-- Primary colors - you can customize these -->
+    <color name="oled_primary">#BB86FC</color>
+    <color name="oled_primary_variant">#3700B3</color>
+    <color name="oled_on_primary">#000000</color>
+    
+    <!-- Secondary colors -->
+    <color name="oled_secondary">#03DAC6</color>
+    <color name="oled_secondary_variant">#018786</color>
+    <color name="oled_on_secondary">#000000</color>
+    
+    <!-- Surface colors -->
+    <color name="oled_surface_variant">#121212</color>
+    <color name="oled_on_surface_variant">#CCCCCC</color>
+    
+    <!-- Error colors -->
+    <color name="oled_error">#CF6679</color>
+    <color name="oled_on_error">#000000</color>
 </resources>

--- a/common/src/androidMain/res/values/theme.xml
+++ b/common/src/androidMain/res/values/theme.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Base App Theme -->
     <style name="AppTheme" parent="Theme.Material3.DynamicColors.DayNight">
         <item name="windowActionBar">false</item>
         <item name="android:windowActionBar">false</item>
@@ -8,5 +9,49 @@
 
         <item name="android:enforceNavigationBarContrast">false</item>
         <item name="android:enforceStatusBarContrast">false</item>
+    </style>
+
+    <!-- OLED Theme with pure black background -->
+    <style name="AppTheme.OLED" parent="Theme.Material3.DynamicColors.DayNight">
+        <!-- Inherit base theme properties -->
+        <item name="windowActionBar">false</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowNoTitle">true</item>
+
+        <item name="android:enforceNavigationBarContrast">false</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <!-- Window colors -->
+        <item name="android:windowBackground">@color/oled_black</item>
+        <item name="android:navigationBarColor">@color/oled_black</item>
+        <item name="android:statusBarColor">@color/oled_black</item>
+        
+        <!-- Material Design colors -->
+        <item name="colorPrimary">@color/oled_primary</item>
+        <item name="colorPrimaryVariant">@color/oled_primary_variant</item>
+        <item name="colorOnPrimary">@color/oled_on_primary</item>
+        <item name="colorSecondary">@color/oled_secondary</item>
+        <item name="colorSecondaryVariant">@color/oled_secondary_variant</item>
+        <item name="colorOnSecondary">@color/oled_on_secondary</item>
+        
+        <!-- Surface colors -->
+        <item name="colorSurface">@color/oled_black</item>
+        <item name="colorOnSurface">@color/oled_white</item>
+        <item name="colorSurfaceVariant">@color/oled_surface_variant</item>
+        <item name="colorOnSurfaceVariant">@color/oled_on_surface_variant</item>
+        
+        <!-- Background colors -->
+        <item name="android:colorBackground">@color/oled_black</item>
+        <item name="colorOnBackground">@color/oled_white</item>
+        
+        <!-- Text colors -->
+        <item name="android:textColorPrimary">@color/oled_white</item>
+        <item name="android:textColorSecondary">@color/oled_gray_light</item>
+        <item name="android:textColorTertiary">@color/oled_gray</item>
+        
+        <!-- Force dark mode -->
+        <item name="android:forceDarkAllowed">true</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
     </style>
 </resources>


### PR DESCRIPTION
I don't currently have a PC setup for Android development and have never used the build system you're using.

Could you build the Android variant and share it here so I can test? If it works correctly I will go about adding a setting to select the OLED theme instead of it being the default like in this pull request. 

Or of course you could do it if you have the want and free time.